### PR TITLE
from_pretrained allows to load weights when they matched

### DIFF
--- a/glasses/models/AutoModel.py
+++ b/glasses/models/AutoModel.py
@@ -214,6 +214,8 @@ class AutoModel:
         Examples:
             >>> AutoModel.pretrained_models() # odict_keys(['resnet18', 'resnet26', .... ])
             >>> AutoModel.from_pretrained('resnet18')
+            >>> # load parameters only when they match
+            >>> AutoModel.from_pretrained('resnet18', n_classes=2)
 
         Args:
             name (str): Name of the model, e.g. 'resnet18'
@@ -226,7 +228,10 @@ class AutoModel:
         """
         model = AutoModel.from_name(name, *args, **kwargs)
         state_dict = storage.get(name)
-        model.load_state_dict(state_dict)
+        try:
+            model.load_state_dict(state_dict)
+        except RuntimeError as e:
+            logger.warning(str(e))
         logger.info(f"Loaded pretrained weights for {name}")
         return model
 

--- a/test/test_auto.py
+++ b/test/test_auto.py
@@ -1,3 +1,4 @@
+from types import new_class
 import pytest
 from glasses.models import AutoTransform, AutoModel, ResNet
 from glasses.models.AutoTransform import Transform
@@ -40,6 +41,12 @@ def test_AutoModel():
     assert len(list(AutoModel.models_table().columns[0].cells)) > 0
 
     assert type(AutoModel.from_name("resnet18").summary()) == ModelStatistics
+
+def test_AutoModel_from_pretrained(caplog):
+    AutoModel.from_pretrained('resnet18')
+    AutoModel.from_pretrained('resnet18', n_classes=2)
+
+    assert "Error(s) in loading state_dict for ResNet:" in caplog.records[1].msg
 
 
 def test_AutoTransform():


### PR DESCRIPTION
Now we can do

```python
AutoModel.from_pretrained("resnet18", n_classes=2)
```

And it will correctly load all the weights where they match without failing